### PR TITLE
tests: fix container creation

### DIFF
--- a/tests/create-test-container.bash
+++ b/tests/create-test-container.bash
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 lxc-create -t download -n mos-test -- -d ubuntu -r jammy -a amd64
-echo -n "lxc.mount.entry = /dev/fuse dev/fuse none bind,create=file 0 0" >> ~/.local/share/lxc/mos-test/config
-echo -n "lxc.include = /usr/share/lxc/config/nesting.conf" >>  ~/.local/share/lxc/mos-test/config
-echo -n "lxc.apparmor.allow_nesting = 1" >>   ~/.local/share/lxc/mos-test/config
+echo "lxc.mount.entry = /dev/fuse dev/fuse none bind,create=file 0 0" >> ~/.local/share/lxc/mos-test/config
+echo "lxc.include = /usr/share/lxc/config/nesting.conf" >>  ~/.local/share/lxc/mos-test/config
+echo "lxc.apparmor.allow_nesting = 1" >>   ~/.local/share/lxc/mos-test/config
 lxc-start -n mos-test
 lxc-wait -n mos-test -s RUNNING
 lxc-attach -n mos-test -- apt-get update


### PR DESCRIPTION
No idea why we were using echo -n, but we do need newlines after each configuration line.

Signed-off-by: Serge Hallyn <serge@hallyn.com>