### PR TITLE
Rename 'zotpath' to 'imagepath'

### DIFF
--- a/cmd/mosb/main.go
+++ b/cmd/mosb/main.go
@@ -17,6 +17,11 @@ func main() {
 		sociCmd,
 	}
 	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "xxx",
+			Usage: "xxx",
+			Value: "x",
+		},
 		cli.BoolFlag{
 			Name:  "debug",
 			Usage: "display additional debug information",
@@ -27,6 +32,8 @@ func main() {
 		if c.Bool("debug") {
 			log.SetLevel(log.DebugLevel)
 		}
+		log.Infof("xxx is set: %v", c.IsSet("xxx"))
+		log.Infof("value of xxx is: %v", c.String("xxx"))
 		return nil
 	}
 

--- a/cmd/mosb/soci.go
+++ b/cmd/mosb/soci.go
@@ -21,8 +21,8 @@ var sociCmd = cli.Command{
 					Value: "",
 				},
 				cli.StringFlag{
-					Name:  "zot-path",
-					Usage: "Zot path on host",
+					Name:  "image-path",
+					Usage: "image path to use in installed repository",
 					Value: "",
 				},
 				cli.StringFlag{
@@ -66,9 +66,9 @@ func doBuildSOCI(ctx *cli.Context) error {
 		return fmt.Errorf("Key filename is required")
 	}
 
-	zotpath := ctx.String("zot-path")
-	if zotpath == "" {
-		return fmt.Errorf("Zot path is required")
+	imagepath := ctx.String("image-path")
+	if imagepath == "" {
+		return fmt.Errorf("--image-path is required")
 	}
 
 	layer := ctx.String("oci-layer")
@@ -78,7 +78,7 @@ func doBuildSOCI(ctx *cli.Context) error {
 
 	soci := mosconfig.SOCI{
 		Layer:       layer,
-		ZotPath:     zotpath,
+		ImagePath:   imagepath,
 		ServiceName: targetname,
 		Version:     version,
 		Meta:        meta,

--- a/pkg/mosconfig/files.go
+++ b/pkg/mosconfig/files.go
@@ -67,7 +67,7 @@ const (
 
 type Target struct {
 	ServiceName  string        `yaml:"service_name"` // name of target
-	ZotPath      string        `yaml:"zotpath"`      // full zot path
+	ImagePath    string        `yaml:"imagepath"`    // full image repository path
 	Version      string        `yaml:"version"`      // docker or oci version tag
 	ServiceType  ServiceType   `yaml:"service_type"`
 	Network      TargetNetwork `yaml:"network"`
@@ -110,7 +110,7 @@ type SysTarget struct {
 }
 type SysTargets []SysTarget
 
-func (s *SysTargets) Contains (needle SysTarget) (SysTarget, bool) {
+func (s *SysTargets) Contains(needle SysTarget) (SysTarget, bool) {
 	for _, t := range *s {
 		if t.Name == needle.Name {
 			return t, true
@@ -163,9 +163,11 @@ func simpleParseInstall(manifestPath string) (InstallFile, error) {
 // certPath is the signing cert.  This comes from install media.
 // caPath is the CA cert to verify certPath.  This comes from signed initrd.
 // srcDir is only passed if we are in an install or update step.  In this
-//    case, we copy the layers from either srcDir/zot or srcDir/oci, into
-//    persistent storage.  If srcDir is "", then we are parsing an installed
-//    manifest and layers are already installed.
+//
+//	case, we copy the layers from either srcDir/zot or srcDir/oci, into
+//	persistent storage.  If srcDir is "", then we are parsing an installed
+//	manifest and layers are already installed.
+//
 // s is the storage driver, currently always an atomfs.
 func ReadVerifyManifest(manifestPath, certPath, caPath, srcDir string, s Storage) (InstallFile, error) {
 	bytes, err := os.ReadFile(manifestPath)

--- a/pkg/mosconfig/install.go
+++ b/pkg/mosconfig/install.go
@@ -57,22 +57,22 @@ func fullnameFromUrl(url string) (string, string, error) {
 	prefix := "docker://"
 	prefixLen := len(prefix)
 	if !strings.HasPrefix(url, prefix) {
-		return "", "", fmt.Errorf("Bad zot URL: bad prefix")
+		return "", "", fmt.Errorf("Bad image URL: bad prefix")
 	}
 	url = url[prefixLen:]
 	addrsplit := strings.SplitN(url, "/", 2)
 	if len(addrsplit) < 2 {
-		return "", "", fmt.Errorf("Bad zot URL: no address")
+		return "", "", fmt.Errorf("Bad image URL: no address")
 	}
 	tagname := addrsplit[1]
 	idx := strings.LastIndex(tagname, ":")
 	if idx == -1 {
-		return "", "", fmt.Errorf("Bad zot URL: no tag")
+		return "", "", fmt.Errorf("Bad image URL: no tag")
 	}
 	name := tagname[:idx]
 	version := tagname[idx+1:]
 	if len(name) < 1 || len(version) < 1 {
-		return "", "", fmt.Errorf("Bad zot URL: short name or tag")
+		return "", "", fmt.Errorf("Bad image URL: short name or tag")
 	}
 	return name, version, nil
 }

--- a/pkg/mosconfig/manifest.go
+++ b/pkg/mosconfig/manifest.go
@@ -133,10 +133,10 @@ func defaultSignature() *object.Signature {
 func (mos *Mos) ReadTargetManifest(t *Target) (ispec.Manifest, ispec.Image, error) {
 	emptyM := ispec.Manifest{}
 	emptyC := ispec.Image{}
-	ociDir := filepath.Join(mos.opts.StorageCache, t.ZotPath)
+	ociDir := filepath.Join(mos.opts.StorageCache, t.ImagePath)
 	oci, err := umoci.OpenLayout(ociDir)
 	if err != nil {
-		return emptyM, emptyC, fmt.Errorf("Failed reading OCI manifest for %s: %w", t.ZotPath, err)
+		return emptyM, emptyC, fmt.Errorf("Failed reading OCI manifest for %s: %w", t.ImagePath, err)
 	}
 	defer oci.Close()
 
@@ -255,7 +255,7 @@ func (mos *Mos) readInstallManifest(gitdir string, l map[string]InstallFile, yNa
 	}
 	defer os.RemoveAll(tmpd)
 
-	manifest, err := ReadVerifyManifest (
+	manifest, err := ReadVerifyManifest(
 		filepath.Join(gitdir, yName),
 		filepath.Join(gitdir, pemName),
 		mos.opts.CaPath,

--- a/pkg/mosconfig/mos.go
+++ b/pkg/mosconfig/mos.go
@@ -250,7 +250,7 @@ func (mos *Mos) GetSystarget(t *Target) (*SysTarget, error) {
 		}
 	}
 
-	return &SysTarget{}, fmt.Errorf("No system target found for %s!", t.ZotPath)
+	return &SysTarget{}, fmt.Errorf("No system target found for %s!", t.ImagePath)
 }
 
 func (mos *Mos) startFsOnly(t *Target) error {

--- a/pkg/mosconfig/oci.go
+++ b/pkg/mosconfig/oci.go
@@ -113,7 +113,7 @@ type SOCI struct {
 	ServiceName string
 
 	// Path under which the layer is found on the host
-	ZotPath string
+	ImagePath string
 
 	// Version to call the service.
 	Version string
@@ -212,7 +212,7 @@ func (soci *SOCI) Generate() error {
 
 	t := Target{
 		ServiceName:  soci.ServiceName,
-		ZotPath:      soci.ZotPath,
+		ImagePath:    soci.ImagePath,
 		Version:      soci.Version,
 		ServiceType:  HostfsService,
 		NSGroup:      "",

--- a/pkg/mosconfig/storage.go
+++ b/pkg/mosconfig/storage.go
@@ -85,7 +85,7 @@ func (a *AtomfsStorage) Mount(t *Target, mountpoint string) (func(), error) {
 	}
 
 	opts := atomfs.MountOCIOpts{
-		OCIDir:       filepath.Join(a.zotPath, t.ZotPath),
+		OCIDir:       filepath.Join(a.zotPath, t.ImagePath),
 		MetadataPath: a.metadataPath(),
 		Tag:          t.Version,
 		Target:       mountpoint,
@@ -284,11 +284,11 @@ func (a *AtomfsStorage) TearDownTarget(name string) error {
 }
 
 func (a *AtomfsStorage) VerifyTarget(t *Target) error {
-	ociDir := filepath.Join(a.zotPath, t.ZotPath)
+	ociDir := filepath.Join(a.zotPath, t.ImagePath)
 
 	oci, err := umoci.OpenLayout(ociDir)
 	if err != nil {
-		return fmt.Errorf("Failed reading OCI manifest for %s: %w", t.ZotPath, err)
+		return fmt.Errorf("Failed reading OCI manifest for %s: %w", t.ImagePath, err)
 	}
 	defer oci.Close()
 
@@ -325,7 +325,7 @@ func (a *AtomfsStorage) VerifyTarget(t *Target) error {
 // implemented.
 func (a *AtomfsStorage) ImportTarget(src string, target *Target) error {
 	if src == "" {
-		return fmt.Errorf("remote zot copy not yet implemented")
+		return fmt.Errorf("remote image copy not yet implemented")
 	}
 	zotDir := filepath.Join(src, "zot")
 	ociDir := filepath.Join(src, "oci")
@@ -347,15 +347,15 @@ func (a *AtomfsStorage) ImportTarget(src string, target *Target) error {
 }
 
 func (a *AtomfsStorage) copyLocalZot(zotSourceDir string, target *Target) error {
-	layerDir := filepath.Join(zotSourceDir, target.ZotPath)
+	layerDir := filepath.Join(zotSourceDir, target.ImagePath)
 	src := fmt.Sprintf("oci:%s:%s", layerDir, target.Version)
-	tpath := filepath.Join(a.zotPath, target.ZotPath)
+	tpath := filepath.Join(a.zotPath, target.ImagePath)
 	if err := EnsureDir(tpath); err != nil {
 		return fmt.Errorf("Failed creating local zot directory %q: %w", tpath, err)
 	}
 	dest := fmt.Sprintf("oci:%s:%s", tpath, target.Version)
 
-	log.Infof("copying %q:%s from local zot ('%s') into zot as '%s'", target.ZotPath, target.Version, src, dest)
+	log.Infof("copying %q:%s from local zot ('%s') into zot as '%s'", target.ImagePath, target.Version, src, dest)
 
 	copyOpts := lib.ImageCopyOpts{Src: src, Dest: dest, Progress: os.Stdout}
 	if err := lib.ImageCopy(copyOpts); err != nil {
@@ -367,7 +367,7 @@ func (a *AtomfsStorage) copyLocalZot(zotSourceDir string, target *Target) error 
 
 func (a *AtomfsStorage) copyLocalOci(ociDir string, target *Target) error {
 	src := fmt.Sprintf("oci:%s:%s", ociDir, target.ServiceName)
-	tpath := filepath.Join(a.zotPath, target.ZotPath)
+	tpath := filepath.Join(a.zotPath, target.ImagePath)
 	err := EnsureDir(tpath)
 	if err != nil {
 		return fmt.Errorf("Failed creating local zot directory %q: %w", tpath, err)

--- a/pkg/mosconfig/uidmap.go
+++ b/pkg/mosconfig/uidmap.go
@@ -75,7 +75,6 @@ func addUIDMap(old []IdmapSet, uidmaps []IdmapSet, t Target) []IdmapSet {
 		}
 	}
 
-
 	// Create a new idmap range
 	uidmap := IdmapSet{
 		Name:   t.NSGroup,

--- a/pkg/mosconfig/update.go
+++ b/pkg/mosconfig/update.go
@@ -121,7 +121,7 @@ func mergeUpdateTargets(old *SysManifest, updated SysTargets, updateType UpdateT
 	}
 
 	return SysManifest{
-		UidMaps: uidmaps,
+		UidMaps:    uidmaps,
 		SysTargets: newtargets,
 	}, nil
 }

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -71,7 +71,7 @@ product: de6c82c5-2e01-4c92-949b-a6545d30fc06
 update_type: complete
 targets:
   - service_name: hostfs
-    zotpath: puzzleos/hostfs
+    imagepath: puzzleos/hostfs
     version: 1.0.0
     manifest_hash: $sum
     service_type: hostfs
@@ -90,7 +90,7 @@ product: de6c82c5-2e01-4c92-949b-a6545d30fc06
 update_type: complete
 targets:
   - service_name: hostfs
-    zotpath: puzzleos/hostfs
+    imagepath: puzzleos/hostfs
     version: 1.0.0
     manifest_hash: $sum
     service_type: hostfs
@@ -99,7 +99,7 @@ targets:
       type: host
     mounts: []
   - service_name: hostfstarget
-    zotpath: puzzleos/hostfstarget
+    imagepath: puzzleos/hostfstarget
     version: 1.0.0
     manifest_hash: $sum
     service_type: fs-only
@@ -118,7 +118,7 @@ product: de6c82c5-2e01-4c92-949b-a6545d30fc06
 update_type: complete
 targets:
   - service_name: hostfs
-    zotpath: puzzleos/hostfs
+    imagepath: puzzleos/hostfs
     version: 1.0.0
     manifest_hash: $sum
     service_type: hostfs
@@ -127,7 +127,7 @@ targets:
       type: host
     mounts: []
   - service_name: hostfstarget
-    zotpath: puzzleos/hostfstarget
+    imagepath: puzzleos/hostfstarget
     version: 1.0.0
     manifest_hash: $sum
     service_type: container

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -22,7 +22,7 @@ product: de6c82c5-2e01-4c92-949b-a6545d30fc06
 update_type: complete
 targets:
   - service_name: hostfs
-    zotpath: puzzleos/hostfs
+    imagepath: puzzleos/hostfs
     version: 1.0.0
     manifest_hash: $sum
     service_type: hostfs
@@ -47,7 +47,7 @@ product: de6c82c5-2e01-4c92-949b-a6545d30fc06
 update_type: complete
 targets:
   - service_name: hostfs
-    zotpath: puzzleos/hostfs
+    imagepath: puzzleos/hostfs
     version: 1.0.0
     manifest_hash: $sum
     service_type: hostfs
@@ -88,7 +88,7 @@ product: de6c82c5-2e01-4c92-949b-a6545d30fc06
 update_type: complete
 targets:
   - service_name: hostfs
-    zotpath: puzzleos/hostfs
+    imagepath: puzzleos/hostfs
     version: 1.0.0
     manifest_hash: $sum
     service_type: hostfs

--- a/tests/soci.bats
+++ b/tests/soci.bats
@@ -33,10 +33,10 @@ EOF
 	# This is whacky in testing:  'mosctl soci mount' will use the
 	# zotpath relative to the configured storage cache.
 	# The skopeo above, to oci:$TMPD/oci/puzzleos/hostfs:1.0.0 , means
-	# that below we must specify version 1.0.0 and zotpath puzzleos/hostfs.
+	# that below we must specify version 1.0.0 and image path puzzleos/hostfs.
 	./mosb soci build --key "${KEYS_DIR}/manifest/privkey.pem" \
 		--cert "${KEYS_DIR}/manifest/cert.pem" \
-		--zot-path puzzleos/hostfs \
+		--image-path puzzleos/hostfs \
 		--oci-layer oci:${TMPD}/oci/puzzleos/hostfs:1.0.0 \
 		--version 1.0.0 \
 		--soci-layer oci:${TMPD}/oci:hostfs-meta-squashfs
@@ -86,7 +86,7 @@ product: de6c82c5-2e01-4c92-949b-a6545d30fc06
 update_type: complete
 targets:
   - service_name: hostfs
-    zotpath: puzzleos/hostfs
+    imagepath: puzzleos/hostfs
     version: 1.0.0
     manifest_hash: $sum
     service_type: hostfs

--- a/tests/update.bats
+++ b/tests/update.bats
@@ -16,7 +16,7 @@ product: de6c82c5-2e01-4c92-949b-a6545d30fc06
 update_type: complete
 targets:
   - service_name: hostfs
-    zotpath: puzzleos/hostfs
+    imagepath: puzzleos/hostfs
     version: 1.0.0
     manifest_hash: $sum
     service_type: hostfs
@@ -40,7 +40,7 @@ product: de6c82c5-2e01-4c92-949b-a6545d30fc06
 update_type: complete
 targets:
   - service_name: hostfs
-    zotpath: puzzleos/hostfs
+    imagepath: puzzleos/hostfs
     version: 1.0.2
     manifest_hash: $sum
     service_type: hostfs
@@ -69,7 +69,7 @@ product: de6c82c5-2e01-4c92-949b-a6545d30fc06
 update_type: complete
 targets:
   - service_name: hostfs
-    zotpath: puzzleos/hostfs
+    imagepath: puzzleos/hostfs
     version: 1.0.0
     manifest_hash: $sum
     service_type: hostfs
@@ -78,7 +78,7 @@ targets:
       type: host
     mounts: []
   - service_name: hostfstarget
-    zotpath: puzzleos/hostfstarget
+    imagepath: puzzleos/hostfstarget
     version: 1.0.0
     manifest_hash: $sum
     service_type: fs-only
@@ -115,7 +115,7 @@ product: de6c82c5-2e01-4c92-949b-a6545d30fc06
 update_type: complete
 targets:
   - service_name: hostfs
-    zotpath: puzzleos/hostfs
+    imagepath: puzzleos/hostfs
     version: 1.0.2
     manifest_hash: $sum
     service_type: hostfs
@@ -124,7 +124,7 @@ targets:
       type: host
     mounts: []
   - service_name: hostfstarget
-    zotpath: puzzleos/hostfstarget
+    imagepath: puzzleos/hostfstarget
     version: 1.0.2
     manifest_hash: $sum
     service_type: fs-only
@@ -173,7 +173,7 @@ product: de6c82c5-2e01-4c92-949b-a6545d30fc06
 update_type: complete
 targets:
   - service_name: hostfs
-    zotpath: puzzleos/hostfs
+    imagepath: puzzleos/hostfs
     version: 1.0.0
     manifest_hash: $sum
     service_type: hostfs
@@ -197,7 +197,7 @@ product: de6c82c5-2e01-4c92-949b-a6545d30fc06
 update_type: partial
 targets:
   - service_name: hostfstarget
-    zotpath: puzzleos/hostfstarget
+    imagepath: puzzleos/hostfstarget
     version: 1.0.2
     manifest_hash: $sum
     service_type: fs-only


### PR DESCRIPTION
This isn't actually zot specific - it's just the path to the image which we should use in the local image repository.

Signed-off-by: Serge Hallyn <serge@hallyn.com>