### PR TITLE
implement mosb iso build

### DIFF
--- a/cmd/mosb/iso.go
+++ b/cmd/mosb/iso.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/project-machine/mos/pkg/mosconfig"
+	"github.com/urfave/cli"
+)
+
+var isoCmd = cli.Command{
+	Name:  "iso",
+	Usage: "build/inspect mos install iso image",
+	Subcommands: []cli.Command{
+		cli.Command{
+			Name:   "build",
+			Action: doBuildISO,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "key",
+					Usage: "path to manifest signing key to use",
+					Value: "",
+				},
+				cli.StringFlag{
+					Name:  "cert",
+					Usage: "path to manifest certificate to use",
+					Value: "",
+				},
+				cli.StringFlag{
+					Name:  "file",
+					Usage: "path to the file with targets list",
+					Value: "targets.yaml",
+				},
+				cli.StringFlag{
+					Name:  "output-file",
+					Usage: "path to which to write the built ISO image",
+					Value: "mos.iso",
+				},
+				cli.StringFlag{
+					Name:  "update-type",
+					Usage: "Update type, complete or partial",
+					Value: "complete",
+				},
+			},
+		},
+	},
+}
+
+func doBuildISO(ctx *cli.Context) error {
+	cert := ctx.String("cert")
+	if cert == "" {
+		return fmt.Errorf("Certificate filename is required")
+	}
+
+	key := ctx.String("key")
+	if key == "" {
+		return fmt.Errorf("Key filename is required")
+	}
+
+	updateType, err := mosconfig.ParseUpdateType(ctx.String("update-type"))
+	if err != nil {
+		return err
+	}
+
+	// TODO product should come from certificate
+	product := "de6c82c5-2e01-4c92-949b-a6545d30fc06"
+
+	iso := mosconfig.ISOConfig{
+		InputFile:  ctx.String("file"),
+		OutputFile: ctx.String("output-file"),
+		Product:    product,
+		Cert:       cert,
+		Key:        key,
+		UpdateType: updateType,
+	}
+
+	// TODO - do we need to do some cosign integration for
+	// verifying containers, or can that be done automatically?
+	return iso.Generate()
+}

--- a/cmd/mosb/main.go
+++ b/cmd/mosb/main.go
@@ -14,6 +14,7 @@ func main() {
 	app.Name = "mosb"
 	app.Version = Version
 	app.Commands = []cli.Command{
+		isoCmd,
 		sociCmd,
 	}
 	app.Flags = []cli.Flag{

--- a/cmd/mosb/main.go
+++ b/cmd/mosb/main.go
@@ -17,11 +17,6 @@ func main() {
 		sociCmd,
 	}
 	app.Flags = []cli.Flag{
-		cli.StringFlag{
-			Name:  "xxx",
-			Usage: "xxx",
-			Value: "x",
-		},
 		cli.BoolFlag{
 			Name:  "debug",
 			Usage: "display additional debug information",
@@ -32,8 +27,6 @@ func main() {
 		if c.Bool("debug") {
 			log.SetLevel(log.DebugLevel)
 		}
-		log.Infof("xxx is set: %v", c.IsSet("xxx"))
-		log.Infof("value of xxx is: %v", c.String("xxx"))
 		return nil
 	}
 

--- a/pkg/mosconfig/install.go
+++ b/pkg/mosconfig/install.go
@@ -11,6 +11,10 @@ func InitializeMos(storeDir, configDir, configFile string) error {
 	baseDir := filepath.Dir(configFile)
 	cPath := filepath.Join(baseDir, "manifestCert.pem")
 	sPath := filepath.Join(baseDir, "install.yaml.signed")
+	// TODO - the next line is not quite right.  The manifestCA.pem
+	// should simply be in / in the signed initrd.  Since we're not
+	// there yet with iso-bootkit, use it from the isodir for
+	// testing.
 	caPath := filepath.Join(baseDir, "manifestCA.pem")
 	if !PathExists(configFile) || !PathExists(cPath) || !PathExists(sPath) || !PathExists(caPath) {
 		return fmt.Errorf("Install manifest or certificate missing")

--- a/pkg/mosconfig/iso.go
+++ b/pkg/mosconfig/iso.go
@@ -1,0 +1,151 @@
+package mosconfig
+
+import (
+	"context"
+        "fmt"
+        "os"
+	"path/filepath"
+
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/opencontainers/umoci"
+	"github.com/project-machine/trust/pkg/trust"
+	"gopkg.in/yaml.v2"
+	"stackerbuild.io/stacker/pkg/lib"
+)
+
+type ISOConfig struct {
+	InputFile  string
+	OutputFile string
+	Cert       string
+	Key        string
+	UpdateType UpdateType
+	Product    string
+}
+
+func (iso *ISOConfig) Generate() error {
+        if !PathExists(iso.InputFile) {
+                return fmt.Errorf("Target file %q not found", iso.InputFile)
+        }
+        if !PathExists(iso.Cert) {
+                return fmt.Errorf("Manifest signing certificate not found")
+        }
+        if !PathExists(iso.Key) {
+                return fmt.Errorf("Manifest signing key not found")
+        }
+        if PathExists(iso.OutputFile) {
+                return fmt.Errorf("Output file %q exists, not overwriting", iso.OutputFile)
+        }
+
+        dir, err := os.MkdirTemp("", "mos-iso")
+        if err != nil {
+                return err
+        }
+        defer os.RemoveAll(dir)
+
+        err = CopyFileBits(iso.Cert, filepath.Join(dir, "install.pem"))
+        if err != nil {
+                return fmt.Errorf("Failure copying certificate into ISO")
+        }
+
+        manifest, inputTargets, err := ManifestFromTargets(iso.InputFile)
+        if err != nil {
+                return fmt.Errorf("Failure creating manifest from target list: %w", err)
+        }
+
+        // Since we're making an old-school iso image, we'll use an
+        // old-school oci layout
+        ociDir := filepath.Join(dir, "oci")
+        if err = EnsureDir(ociDir); err != nil {
+                return err
+        }
+
+        for key, t := range inputTargets {
+                sum, err := copyToOcidir(t.ImagePath, t.ServiceName, ociDir)
+		if err != nil {
+                        return err
+                }
+		manifest.Targets[key].ManifestHash = sum
+        }
+
+	manifest.Version = CurrentInstallFileVersion
+	manifest.ImageType = ISO
+	manifest.Product = iso.Product
+	manifest.StorageType = AtomfsStorageType
+	manifest.UpdateType = iso.UpdateType
+
+        bytes, err := yaml.Marshal(&manifest)
+        if err != nil {
+                return fmt.Errorf("Failure serializing the install manifest")
+        }
+
+        mPath := filepath.Join(dir, "install.yaml")
+        if err = os.WriteFile(mPath, bytes, 0640); err != nil {
+                return fmt.Errorf("Failed writing out install.yaml: %w", err)
+        }
+
+        sPath := filepath.Join(dir, "install.yaml.signed")
+        if err = trust.Sign(mPath, sPath, iso.Key); err != nil {
+                return fmt.Errorf("Failed signing the install manifest: %w", err)
+        }
+
+        // TODO - create an efi directory and copy the UKI and shim
+
+        // Create the ISO
+        cmd := []string{
+                "xorriso",
+                "-compliance", "iso_9660_level=3",
+                "-as", "mkisofs",
+                "-V", "MOS-INSTALL",
+                // "-e", "loader/images/efi-esp.img", //Not doing this yet...
+                "-isohybrid-gpt-basdat",
+                "-partition_cyl_align", "all",
+                "-no-emul-boot", "-isohybrid-gpt-basdat",
+                "-o", iso.OutputFile,
+                dir}
+        if err = RunCommand(cmd...); err != nil {
+                return fmt.Errorf("Error creating ISO.\nCommand: %#v\nError: %w", cmd, err)
+        }
+
+        return nil
+}
+
+// copyToOcidir - copy a layer from the oci image path or docker url
+// specified in the install yaml, into the ISO/oci/ directory.
+// Also get the shasum of the image manifest, and return that as the
+// first argument.
+func copyToOcidir(src, name, ociDir string) (string, error) {
+	dest := fmt.Sprintf("oci:%s:%s", ociDir, name)
+	copyOpts := lib.ImageCopyOpts{Src: src, Dest: dest, Progress: os.Stdout}
+	if err := lib.ImageCopy(copyOpts); err != nil {
+		return "", fmt.Errorf("failed copying layer %q to %q: %w", src, dest, err)
+	}
+
+	oci, err := umoci.OpenLayout(ociDir)
+	if err != nil {
+		return "", err
+	}
+	defer oci.Close()
+
+	descriptorPaths, err := oci.ResolveReference(context.Background(), name)
+	if err != nil {
+		return "", err
+	}
+
+	if len(descriptorPaths) != 1 {
+		return "", fmt.Errorf("bad descriptor %q in %q", name, ociDir)
+	}
+
+	blob, err := oci.FromDescriptor(context.Background(), descriptorPaths[0].Descriptor())
+	if err != nil {
+		return"", err
+	}
+	defer blob.Close()
+
+	if blob.Descriptor.MediaType != ispec.MediaTypeImageManifest {
+		return "", fmt.Errorf("descriptor does not point to a manifest: %s", blob.Descriptor.MediaType)
+	}
+
+	shasum := blob.Descriptor.Digest.Encoded()
+
+	return shasum, nil
+}

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -10,7 +10,8 @@ function teardown() {
 
 @test "simple mos install from local oci" {
 	good_install hostfsonly
-	[ -f $TMPD/atomfs-store/puzzleos/hostfs/index.json ]
+	cat $TMPD/install.yaml
+	[ -f $TMPD/atomfs-store/busybox-squashfs/index.json ]
 	[ -f $TMPD/config/manifest.git/manifest.yaml ]
 }
 


### PR DESCRIPTION
It takes a bare version of a install.yaml, consisting only of
targets, something like:

targets:
  - service_name: hostfs
    imagepath: oci:zothub:busybox-squashfs
    version: 1.0.0
    service_type: hostfs
    nsgroup: ""
    network:
      type: host
  - service_name: hostfstarget
    imagepath: docker://zothub.io/tools/busybox:stable
    version: 1.0.0
    service_type: fs-only
    nsgroup: ""
    network:
      type: none

It will rewrite the imagepath to reflect what to expect the
installed image to look like on the host.  It will create an
ISO containing a full install.yaml, the specified manifest
signing certificate and signed manifest, and an oci layout
with each specified target installed referenced by the
target.service_name as the image name.

Eventually we'll want this to also create an EFI partition
with the appropriate signed UKI and shim, to support simple
installation by ISO boot.

Signed-off-by: Serge Hallyn <serge@hallyn.com>
