### PR TITLE
Drop an unintentional go mod replace.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,4 +118,3 @@ require (
 go 1.19
 
 replace github.com/jsipprell/keyctl => github.com/hallyn/keyctl v1.0.4-0.20211206210026-67b989e45620
-replace github.com/project-machine/trust => github.com/joylatten/trust v0.0.0-20230209224722-b3ae69249664

--- a/go.sum
+++ b/go.sum
@@ -501,8 +501,6 @@ github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
-github.com/joylatten/trust v0.0.0-20230209224722-b3ae69249664 h1:WvDpaXxPfv8dnQAJ1WXJB/oyoNlfkyMDSrW9Lh427/I=
-github.com/joylatten/trust v0.0.0-20230209224722-b3ae69249664/go.mod h1:kLRGdPRHyifUjjPte6c642amoqz0edtlPpk5GoO6KRo=
 github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7/go.mod h1:2iMrUgbbvHEiQClaW2NsSzMyGHqN+rDFqY705q49KG0=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -694,8 +692,6 @@ github.com/plus3it/gorecurcopy v0.0.1/go.mod h1:NvVTm4RX68A1vQbHmHunDO4OtBLVroT6
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
-github.com/project-machine/trust v0.0.0-20230125232253-03cd08bc827d h1:m43Geh6ld7Nb3yX+5AOyF9D1XrnFwTE8MnGEZTlqHs8=
-github.com/project-machine/trust v0.0.0-20230125232253-03cd08bc827d/go.mod h1:kLRGdPRHyifUjjPte6c642amoqz0edtlPpk5GoO6KRo=
 github.com/project-machine/trust v0.0.0-20230131225948-2affc53389e5 h1:+fe7pYIaW6NfWAK/+lH3/vwpcxyYeq/1pG6FKbeBmtA=
 github.com/project-machine/trust v0.0.0-20230131225948-2affc53389e5/go.mod h1:kLRGdPRHyifUjjPte6c642amoqz0edtlPpk5GoO6KRo=
 github.com/prometheus/client_golang v0.0.0-20180209125602-c332b6f63c06/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=


### PR DESCRIPTION
Serge said that this was an unintentional change in his last commit.

Remove the 'replace' with:

  go mod edit -dropreplace=github.com/project-machine/trust
  go mod tidy