### PR TITLE
test(zot): add test to work with a OCI registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,23 @@
 BUILD_TAGS = containers_image_openpgp
+TOOLSDIR := $(shell pwd)/hack/tools
+PATH := bin:$(TOOLSDIR)/bin:$(PATH)
+# OCI registry
+ZOT := $(TOOLSDIR)/bin/zot
+ZOT_VERSION := 1.4.3
+# OCI registry clients
+ORAS := $(TOOLSDIR)/bin/oras
+ORAS_VERSION := 1.0.0-rc.1
+
+$(ZOT):
+	mkdir -p $(TOOLSDIR)/bin
+	curl -Lo $(ZOT) https://github.com/project-zot/zot/releases/download/v$(ZOT_VERSION)/zot-linux-amd64-minimal
+	chmod +x $(ZOT)
+
+$(ORAS):
+	mkdir -p $(TOOLSDIR)/bin
+	curl -Lo oras.tar.gz https://github.com/oras-project/oras/releases/download/v$(ORAS_VERSION)/oras_$(ORAS_VERSION)_linux_amd64.tar.gz
+	tar xvzf oras.tar.gz -C $(TOOLSDIR)/bin oras
+	rm oras.tar.gz
 
 all: mosctl mosb
 
@@ -9,7 +28,7 @@ mosb: cmd/mosb/*.go pkg/mosconfig/*.go
 	go build -tags "$(BUILD_TAGS)" ./cmd/mosb
 
 .PHONY: test
-test: mosctl
+test: mosctl $(ORAS) $(ZOT)
 	bats tests/install.bats
 	bats tests/rfs.bats
 	bats tests/soci.bats
@@ -19,3 +38,4 @@ test: mosctl
 
 clean:
 	rm -f mosb mosctl
+	rm -rf $(TOOLSDIR)

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -1,11 +1,13 @@
 load helpers
 
 function setup() {
-	common_setup
+  common_setup
+  zot_setup
 }
 
 function teardown() {
-	common_teardown
+  zot_teardown
+  common_teardown
 }
 
 @test "simple mos install from local oci" {
@@ -64,6 +66,46 @@ EOF
 	cp "${KEYS_DIR}/manifest-ca/cert.pem" "$TMPD/manifestCA.pem"
 	./mosctl install -c $TMPD/config -a $TMPD/atomfs-store -f $TMPD/install.yaml
 	[ -f $TMPD/atomfs-store/puzzleos/hostfs/index.json ]
+}
+
+@test "simple mos install from local zot with references" {
+	sum=$(manifest_shasum busybox-squashfs)
+	cat > $TMPD/install.yaml << EOF
+version: 1
+product: de6c82c5-2e01-4c92-949b-a6545d30fc06
+update_type: complete
+targets:
+  - service_name: hostfs
+    imagepath: puzzleos/hostfs
+    version: 1.0.0
+    manifest_hash: $sum
+    service_type: hostfs
+    nsgroup: ""
+    network:
+      type: host
+    mounts: []
+EOF
+  openssl dgst -sha256 -sign "${KEYS_DIR}/manifest/privkey.pem" \
+    -out "$TMPD/install.yaml.signed" "$TMPD/install.yaml"
+  mkdir -p $TMPD/zot/c3
+  skopeo copy --format=oci --dest-tls-verify=false oci:zothub:busybox-squashfs docker://$ZOT_HOST:$ZOT_PORT/oci:hostfs
+  skopeo copy --src-tls-verify=false docker://$ZOT_HOST:$ZOT_PORT/oci:hostfs oci:$TMPD/oci:hostfs
+  # push the install manifest
+  oras push --plain-http --image-spec v1.1-image $ZOT_HOST:$ZOT_PORT/machine/install:1.0.0 "$TMPD/install.yaml":vnd.machine.install
+  # make a copy of the cert, which we will push and restore
+  mkdir -p "$TMPD/manifest-ca"
+  cp "${KEYS_DIR}/manifest-ca/cert.pem" "$TMPD/manifest-ca"
+  # make this a cert a reference to the install manifest and remove the local copy
+  oras attach --plain-http --image-spec v1.1-image --artifact-type vnd.machine.public-key $ZOT_HOST:$ZOT_PORT/machine/install:1.0.0 "$TMPD/manifest-ca/cert.pem"
+  rm "$TMPD/manifest-ca/cert.pem"
+  # ensure this association is made on the OCI registry
+  oras discover --plain-http -o json --artifact-type vnd.machine.public-key $ZOT_HOST:$ZOT_PORT/machine/install:1.0.0
+  PUBKEY=$(oras discover --plain-http -o json --artifact-type vnd.machine.public-key $ZOT_HOST:$ZOT_PORT/machine/install:1.0.0 | jq .manifests[0].digest | tr -d \")
+  # restore the cert copy from the OCI registry
+  oras pull --plain-http -o "$TMPD/manifest-ca/" $ZOT_HOST:$ZOT_PORT/machine/install@$PUBKEY
+  cp "$TMPD/manifest-ca/cert.pem" "$TMPD/manifestCA.pem"
+  ./mosctl install -c $TMPD/config -a $TMPD/atomfs-store -f $TMPD/install.yaml
+  [ -f $TMPD/atomfs-store/puzzleos/hostfs/index.json ]
 }
 
 @test "mos install with bad version" {


### PR DESCRIPTION
Add a test to actually use zot to push images and other attached artifacts.