### PR TITLE
Add build tag containers_image_openpgp to drop libgpgme deps.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
+BUILD_TAGS = containers_image_openpgp
+
 all: mosctl mosb
 
 mosctl: cmd/mosctl/*.go pkg/mosconfig/*.go
-	go build ./cmd/mosctl
+	go build -tags "$(BUILD_TAGS)" ./cmd/mosctl
 
 mosb: cmd/mosb/*.go pkg/mosconfig/*.go
-	go build ./cmd/mosb
+	go build -tags "$(BUILD_TAGS)" ./cmd/mosb
 
 .PHONY: test
 test: mosctl


### PR DESCRIPTION
The net change of this commit is to drop the following C-go dependencies from the 'mosctl' binary:

  * libassuan.so.0
  * libgpg-error.so.0
  * libgpgme.so.11

The net change on size of the binary is negligible, it is reduced by ~200kb of a 28mb binary.

Per https://github.com/containers/image/blob/main/README.md

> containers_image_openpgp: Use a Golang-only OpenPGP
> implementation for signature verification instead of
> the default cgo/gpgme-based implementation; the primary
> downside is that creating new signatures with the
> Golang-only implementation is not supported.