### PR TITLE
drop lxc test from 'make test'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ test: mosctl $(ORAS) $(ZOT)
 	bats tests/rfs.bats
 	bats tests/soci.bats
 	bats tests/activate.bats
-	bats tests/lxc.bats
 	bats tests/update.bats
 
 clean:


### PR DESCRIPTION
Github actions seems maddenlingly unable to start an lxc container.  The jammy container ends up with only an /sbin/init.  The lxc container tests were a workaround anyway - we really want to run them in a VM with 'machine'.  So let's disable this test for now and hopefully hook up machine tests next week.

You can still run it by hand locally by doing 'bats lxc/test'.