### PR TITLE
No longer ignore 'make test' failures in github workflow.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,8 +67,7 @@ jobs:
           make
       - name: test
         run: |
-          timeout 20m make test ||
-              echo "Ignoring error in 'make test' [exit code $?]"
+          timeout 20m make test
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Previous commit in #36 disabled the one test that would fail, so this should be expected to pass now.