### PR TITLE
bump trust dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,11 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc2
 	github.com/opencontainers/umoci v0.4.8-0.20220412065115-12453f247749
 	github.com/pkg/errors v0.9.1
-	github.com/project-machine/trust v0.0.0-20230501220237-85fe1d884837
+	github.com/project-machine/trust v0.0.0-20230512150658-95f9d92de57b
+	github.com/rekby/gpt v0.0.0-20200219180433-a930afbc6edc
 	github.com/urfave/cli v1.22.12
 	golang.org/x/sys v0.7.0
+	golang.org/x/text v0.9.0
 	gopkg.in/yaml.v2 v2.4.0
 	stackerbuild.io/stacker v0.40.2-0.20230121032931-06affd857c1c
 )
@@ -92,7 +94,6 @@ require (
 	github.com/pkg/xattr v0.4.9 // indirect
 	github.com/plus3it/gorecurcopy v0.0.1 // indirect
 	github.com/proglottis/gpgme v0.1.3 // indirect
-	github.com/rekby/gpt v0.0.0-20200219180433-a930afbc6edc // indirect
 	github.com/rekby/mbr v0.0.0-20190325193910-2b19b9cdeebc // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
@@ -124,7 +125,6 @@ require (
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/term v0.7.0 // indirect
-	golang.org/x/text v0.9.0 // indirect
 	golang.org/x/tools v0.7.0 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/grpc v1.54.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -451,6 +451,8 @@ github.com/proglottis/gpgme v0.1.3 h1:Crxx0oz4LKB3QXc5Ea0J19K/3ICfy3ftr5exgUK1AU
 github.com/proglottis/gpgme v0.1.3/go.mod h1:fPbW/EZ0LvwQtH8Hy7eixhp1eF3G39dtx7GUN+0Gmy0=
 github.com/project-machine/trust v0.0.0-20230501220237-85fe1d884837 h1:GI8+tn2lIuh/ZCOyiW7ZyDgChzNUCuVY2XHWkUndU0E=
 github.com/project-machine/trust v0.0.0-20230501220237-85fe1d884837/go.mod h1:J9tvl0JUo0LSPJa+lRRCZCmQb2bWQIUqefaUseBuZSI=
+github.com/project-machine/trust v0.0.0-20230512150658-95f9d92de57b h1:/lvF/tiRp7kEG04UB8pn58XIdlqRn4EYcEeDovJQLO4=
+github.com/project-machine/trust v0.0.0-20230512150658-95f9d92de57b/go.mod h1:J9tvl0JUo0LSPJa+lRRCZCmQb2bWQIUqefaUseBuZSI=
 github.com/prometheus/client_golang v1.15.0 h1:5fCgGYogn0hFdhyhLbw7hEsWxufKtY9klyvdNfFlFhM=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.3.0 h1:UBgGFHqYdG/TPFD1B1ogZywDqEkwp3fBMvqdiQ7Xew4=


### PR DESCRIPTION
This is to get the fix to initrd-setup to create /priv/factory, without which some boots can fail.