### PR TITLE
Always use ttyS0 as primary console, with tty0 as secondary

### DIFF
--- a/pkg/mosconfig/disk.go
+++ b/pkg/mosconfig/disk.go
@@ -242,9 +242,9 @@ func WriteBootEntry() error {
 	}
 
 	shimPath := "\\efi\\boot\\shim.efi"
-	argsPath := "\\efi\\boot\\kernel.efi root=soci:name=mosboot,repo=local"
+	argsString := "\\efi\\boot\\kernel.efi root=soci:name=mosboot,repo=local console=tty0 console=ttyS0,115200n8"
 
-	kname, err := toUCS2(argsPath)
+	kname, err := toUCS2(argsString)
 	if err != nil {
 		return errors.Wrapf(err, "Failure getting UCS2 converted shim arguments")
 	}

--- a/pkg/mosconfig/install.go
+++ b/pkg/mosconfig/install.go
@@ -183,7 +183,7 @@ func InitializeMos(ctx *cli.Context, opts InstallOpts) error {
 const StartupNSH = `
 fs0:
 cd fs0:/efi/boot/
-shim.efi kernel.efi root=soci:name=mosboot,repo=local
+shim.efi kernel.efi root=soci:name=mosboot,repo=local console=tty0 console=ttyS0,115200n8
 `
 
 func (mos *Mos) InstallNewBoot(boot Target) error {


### PR DESCRIPTION
This should still show us output when using gui, but let us use automation.