### PR TITLE
Strip mosctl and mosb binaries.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ GO_SRC=$(shell find cmd pkg  -name "*.go")
 all: mosctl mosb $(ZOT) $(ORAS)
 
 mosctl: .made-gofmt $(GO_SRC)
-	go build -tags "$(BUILD_TAGS)" ./cmd/mosctl
+	go build -tags "$(BUILD_TAGS)" -ldflags "-s -w" ./cmd/mosctl
 
 mosb: .made-gofmt $(GO_SRC)
-	go build -tags "$(BUILD_TAGS)" ./cmd/mosb
+	go build -tags "$(BUILD_TAGS)" -ldflags "-s -w" ./cmd/mosb
 
 $(ZOT):
 	mkdir -p $(TOOLSDIR)/bin


### PR DESCRIPTION
from https://pkg.go.dev/cmd/link

 > -s Omit the symbol table and debug information.
 > -w Omit the DWARF symbol table.

And for other reference, from
https://honnef.co/articles/stripping-go-elf-binaries-is-safe/

 > To conclude: stripping Go binaries, at least on systems that use ELF
 > binaries, is safe and has been safe since 2011. Similarly, using the Go
 > linker’s -s flag has been safe for many years, various short-lived bugs
 > aside.

| file   | before   | after    | reduced |
| ---    | ------   | -----    | ----    |
| mosb   | 32092624 | 22681824 | 29%     |
| mosctl | 33309736 | 23557248 | 29%     |