### PR TITLE
Add a 'deps' make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,10 @@ gofmt: .made-gofmt
 	  [ -z "$$o" ] || { echo "gofmt made changes: $$o" 1>&2; exit 1; }
 	@touch $@
 
+deps: mosctl mosb $(ORAS) $(REGCTL) $(ZOT) $(TRUST)
+
 .PHONY: test
-test: mosctl mosb $(ORAS) $(REGCTL) $(ZOT) $(TRUST)
+test: deps
 	bats tests/install.bats
 	bats tests/rfs.bats
 	bats tests/activate.bats


### PR DESCRIPTION
This mainly downloads the hack/tools/ binaries we'll need during testing, so we can jump straight to one bats test without doing a full 'make test'.