### PR TITLE
Override mosctl in snakeoil kernel when testing

### DIFF
--- a/cmd/trust/keyset.go
+++ b/cmd/trust/keyset.go
@@ -260,6 +260,12 @@ var keysetCmd = cli.Command{
 					Usage: "Version of bootkit artifacts to use",
 					Value: trust.BootkitVersion,
 				},
+				cli.StringFlag{
+					Name:   "mosctl-path",
+					Usage:  "A path to a custom mosctl binary to insert",
+					Hidden: true,
+					Value:  "",
+				},
 			},
 		},
 		{
@@ -322,6 +328,8 @@ func doAddKeyset(ctx *cli.Context) error {
 		return errors.New("Please specify keyset name")
 	}
 
+	mosctlPath := ctx.String("mosctl-path")
+
 	bootkitVersion := ctx.String("bootkit-version")
 	Org := ctx.StringSlice("org")
 	if Org == nil {
@@ -354,7 +362,7 @@ func doAddKeyset(ctx *cli.Context) error {
 	}
 
 	// Now create the bootkit artifacts
-	if err = trust.SetupBootkit(keysetName, bootkitVersion); err != nil {
+	if err = trust.SetupBootkit(keysetName, bootkitVersion, mosctlPath); err != nil {
 		return fmt.Errorf("Failed creating bootkit artifacts for keyset %q: (%w)", keysetName, err)
 	}
 

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -6,7 +6,7 @@ function trust_setup {
 	MDIR=~/.local/share/machine
 	BACKUP=~/.local/share/machine.backup
 	export TOPDIR="$(git rev-parse --show-toplevel)"
-	export PATH=${TOP_DIR}:$PATH
+	export PATH=${TOPDIR}:$PATH
 	if [ -d "$BACKUP" ]; then
 		rm -rf "$BACKUP"
 	fi
@@ -38,9 +38,10 @@ function common_setup {
 	export TMPUD=$(mktemp -d "${PWD}/batstest-XXXXX")
 	mkdir -p "$TMPD/config" "$TMPD/atomfs-store" "$TMPD/scratch-writes" "$TMPD/bin"
 
+	export TOPDIR="$(git rev-parse --show-toplevel)"
 	export PATH="$PATH:${TOPDIR}/hack/tools/bin"
 
-	trust keyset list | grep snakeoil || trust keyset add --bootkit-version=${ROOTFS_VERSION} snakeoil
+	trust keyset list | grep snakeoil || trust keyset add --bootkit-version=${ROOTFS_VERSION} --mosctl-path=${TOPDIR}/mosctl snakeoil
 	export CA_PEM=~/.local/share/machine/trust/keys/snakeoil/manifest-ca/cert.pem
 	export M_CERT=~/.local/share/machine/trust/keys/snakeoil/manifest/default/cert.pem
 	export M_KEY=~/.local/share/machine/trust/keys/snakeoil/manifest/default/privkey.pem


### PR DESCRIPTION
Add a hidden --mosctl-path flag to 'trust keyset add'.  If set, then an extra cpio is added to initrd which sets /usr/bin/mosctl to the provided path.

Use this flag during testing, so that we can pass tests with a new mosctl even if bootkit shipped with a different mosctl.