### PR TITLE
stop redirecting project-machine/machine

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,8 +92,8 @@ jobs:
 
       - name: test preparation
         run: |
-          wget -O ~/bin/machine --progress=dot:mega https://github.com/project-machine/machine/releases/download/0.0.4/machine
-          wget -O ~/bin/machined --progress=dot:mega https://github.com/project-machine/machine/releases/download/0.0.4/machined
+          wget -O ~/bin/machine --progress=dot:mega https://github.com/project-machine/machine/releases/download/v0.1.2/machine-linux-amd64
+          wget -O ~/bin/machined --progress=dot:mega https://github.com/project-machine/machine/releases/download/v0.1.2/machined-linux-amd64
           chmod 755 ~/bin/machine ~/bin/machined
           mkdir -p ~/.config/systemd/user/
           export  PATH=~/bin:$PATH

--- a/go.mod
+++ b/go.mod
@@ -174,5 +174,3 @@ toolchain go1.21.0
 replace github.com/jsipprell/keyctl => github.com/hallyn/keyctl v1.0.4-0.20230720164202-b9476cd969e8
 
 replace github.com/containers/image/v5 => github.com/hallyn/image/v5 v5.0.0-20230329035821-bb0673fd450d
-
-replace github.com/project-machine/machine => github.com/hallyn/machine v0.0.0-20230928184440-db1ec7acdad6

--- a/go.sum
+++ b/go.sum
@@ -1882,8 +1882,6 @@ github.com/hallyn/image/v5 v5.0.0-20230329035821-bb0673fd450d h1:J/CgvQVzMpKQaMt
 github.com/hallyn/image/v5 v5.0.0-20230329035821-bb0673fd450d/go.mod h1:GBjr6Lzt0cQdaVTi9hTNSmSWy3aXRFkRprIWbqYGUKc=
 github.com/hallyn/keyctl v1.0.4-0.20230720164202-b9476cd969e8 h1:3Ar9+nx3xcpq4NjFMYHSXcf18qYtCWyanIDyfctYOjQ=
 github.com/hallyn/keyctl v1.0.4-0.20230720164202-b9476cd969e8/go.mod h1:64s6WpBtruURX3w8W/vhWj1/uh+nOm7vUXSJlK5+KMs=
-github.com/hallyn/machine v0.0.0-20230928184440-db1ec7acdad6 h1:3Hfm0Qyin/POPB4aXABkC1cqB0f97/AOeXXZFyIVBiU=
-github.com/hallyn/machine v0.0.0-20230928184440-db1ec7acdad6/go.mod h1:pjru0EkLoBhdLQ1szLxJIqiMkUgezdwMjsaq/ijBZOw=
 github.com/hanwen/go-fuse/v2 v2.2.0/go.mod h1:B1nGE/6RBFyBRC1RRnf23UpwCdyJ31eukw34oAKukAc=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.10.1/go.mod h1:XjsvQN+RJGWI2TWy1/kqaE16HrR2J/FWgkYjdZQsX9M=
@@ -2695,6 +2693,8 @@ github.com/proglottis/gpgme v0.1.3 h1:Crxx0oz4LKB3QXc5Ea0J19K/3ICfy3ftr5exgUK1AU
 github.com/proglottis/gpgme v0.1.3/go.mod h1:fPbW/EZ0LvwQtH8Hy7eixhp1eF3G39dtx7GUN+0Gmy0=
 github.com/project-machine/bootkit v0.0.15 h1:EAeilYMiBnsliLc+3BejqIwN8seir2fQ8aL8Lg93mkY=
 github.com/project-machine/bootkit v0.0.15/go.mod h1:02BdQ6/ClxWdwPOIVYxpRNJIJD2eFcg8iz2Q1phJchU=
+github.com/project-machine/machine v0.1.2 h1:/detDExvftlN+PvJWP57tUS6NFLPtHWc+m3b4/NhFq4=
+github.com/project-machine/machine v0.1.2/go.mod h1:pjru0EkLoBhdLQ1szLxJIqiMkUgezdwMjsaq/ijBZOw=
 github.com/project-machine/qcli v0.2.1 h1:rIRItjdkeBbD4NIxYyTkxCeJIolGHdniJ51Phfg2Ols=
 github.com/project-machine/qcli v0.2.1/go.mod h1:N7+8pGJWD/PvJOmzY6dmor4DYnG18bW/Mwa5Ful0GEs=
 github.com/project-stacker/stacker v0.21.2 h1:tw9v0sxqnA1mNyxZzhTEIN2aKSbtRHWbGXVRPhrGic4=

--- a/tests/livecd1.bats
+++ b/tests/livecd1.bats
@@ -36,6 +36,7 @@ function teardown() {
       name: ${VMNAME}
       uefi: true
       uefi-vars: $HOME/.local/share/machine/trust/keys/snakeoil/bootkit/ovmf-vars.fd
+      uefi-code: /usr/share/OVMF/OVMF_CODE.secboot.fd
       cdrom: livecd.iso
       boot: cdrom
       tpm: true

--- a/tests/livecd2.bats
+++ b/tests/livecd2.bats
@@ -50,6 +50,7 @@ function teardown() {
       name: ${VMNAME}
       uefi: true
       uefi-vars: $HOME/.local/share/machine/trust/keys/snakeoil/bootkit/ovmf-vars.fd
+      uefi-code: /usr/share/OVMF/OVMF_CODE.secboot.fd
       cdrom: $HOME/.local/share/machine/trust/keys/snakeoil/artifacts/provision.iso
       boot: cdrom
       tpm: true


### PR DESCRIPTION
Now that the api we need is merged, use standard v0.1.2.