### PR TITLE
force stacker-push-action to use newer stacker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: project-stacker/stacker-build-push-action@main
         with:
+          version: v1.0.0-rc7
           file: 'layers/stacker.yaml'
           build-args: |
             ZOT_VERSION=2.0.0-rc5


### PR DESCRIPTION
Since we use newer stacker to build layers, we had to make the breaking change from /stacker to /stacker/imports.  But then stacker-push-action's default 0.40.x stacker breaks.  So bump it as well.