### PR TITLE
CI: Update stacker version in stacker-build-push-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: project-stacker/stacker-build-push-action@main
         with:
-          version: v1.0.0-rc7
+          version: v1.0.0-rc8
           file: 'layers/stacker.yaml'
           build-args: |
             ZOT_VERSION=2.0.0-rc5


### PR DESCRIPTION
We need to specify v1.0.0-rc8 to avoid a symlink bug in earlier stacker.