### PR TITLE
ci: chnage how we find tags to pass to stacker-build-push-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,8 @@ jobs:
             mosctl-linux-amd64
             trust-linux-amd64
 
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: publish provision and install layer
         if: startsWith(github.ref, 'refs/tags/')
         uses: project-stacker/stacker-build-push-action@main
@@ -78,7 +80,7 @@ jobs:
             ROOTFS_VERSION=v0.0.17.231018
             TOPDIR=${{ env.TOPDIR }}
           url: docker://zothub.io/machine/bootstrap
-          tags: ${{ github.event.release.tag_name }}
+          tags: ${{ env.RELEASE_VERSION }}
           username: ${{ secrets.ZOTHUB_USERNAME }}
           password: ${{ secrets.ZOTHUB_PASSWORD }}
 


### PR DESCRIPTION
We are getting an error about tags being empty.  The intertubes, for instance
https://stackoverflow.com/questions/58177786/get-the-current-pushed-tag-in-github-actions, suggests that that actually cna't work.  Use another suggested way.