### PR TITLE
ci: fix the OCi image publish url

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
             ZOT_VERSION=2.0.0-rc5
             ROOTFS_VERSION=v0.0.17.231018
             TOPDIR=${{ env.TOPDIR }}
-          url: docker://zothub.io/machine/bootstrap
+          url: docker://zothub.io/machine/bootkit
           tags: ${{ env.RELEASE_VERSION }}
           username: ${{ secrets.ZOTHUB_USERNAME }}
           password: ${{ secrets.ZOTHUB_PASSWORD }}


### PR DESCRIPTION
s/bootstrap/bootkit