### PR TITLE
mosb publish: auto-fill bootkit and hostfs layers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
           echo "PATH=$HOME/bin:$PATH" >> $GITHUB_ENV
       - name: Check out git
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up golang
         uses: actions/setup-go@v3
         with:
@@ -77,7 +79,7 @@ jobs:
           dir: 'layers'
           build-args: |
             ZOT_VERSION=2.0.0-rc5
-            ROOTFS_VERSION=v0.0.17.231018
+            ROOTFS_VERSION=v0.0.18.231121
             TOPDIR=${{ env.TOPDIR }}
           url: docker://zothub.io/machine/bootkit
           layer-type: squashfs

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ else
 #error "Unsupported architecture: $(archout)"
 endif
 
+CLEAN_VERSION ?= $(shell git describe --abbrev=0)
 MAIN_VERSION ?= $(shell git describe --always --dirty || echo no-git)
 ifeq ($(MAIN_VERSION),$(filter $(MAIN_VERSION), "", no-git))
 $(error "Bad value for MAIN_VERSION: '$(MAIN_VERSION)'")
@@ -33,6 +34,7 @@ all: mosctl mosb trust $(ZOT) $(ORAS) $(REGCTL)
 
 VERSION_LDFLAGS=-X github.com/project-machine/mos/pkg/mosconfig.Version=$(MAIN_VERSION) \
 	-X github.com/project-machine/mos/pkg/trust.Version=$(MAIN_VERSION) \
+	-X github.com/project-machine/mos/pkg/trust.RelVersion=$(CLEAN_VERSION) \
 	-X github.com/project-machine/mos/pkg/mosconfig.LayerVersion=0.0.4 \
 	-X github.com/project-machine/mos/pkg/trust.BootkitVersion=$(BOOTKIT_VERSION)
 

--- a/cmd/mosb/manifest.go
+++ b/cmd/mosb/manifest.go
@@ -37,6 +37,10 @@ var manifestCmd = cli.Command{
 					Usage: "Password to authenticate to OCI repository.  Taken from stdin if user but no password is provided",
 					Value: "",
 				},
+				cli.BoolFlag{
+					Name:  "skip-boot, skip-bootkit",
+					Usage: "Do not add in a bootkit layer",
+				},
 			},
 		},
 	},

--- a/pkg/mosconfig/mkboot.go
+++ b/pkg/mosconfig/mkboot.go
@@ -497,7 +497,7 @@ func BuildProvisioner(keysetName, projectName, isofile string) error {
 	}
 
 	fullproject := keysetName + ":" + projectName
-	err = PublishManifest(fullproject, repo, name, manifestpath)
+	err = PublishManifest(fullproject, repo, name, manifestpath, SkipBootkit)
 	if err != nil {
 		return errors.Wrapf(err, "Failed writing manifest artifacts to local zot")
 	}
@@ -556,7 +556,7 @@ func BuildInstaller(keysetName, projectName, isofile string) error {
 	}
 
 	fullproject := keysetName + ":" + projectName
-	err = PublishManifest(fullproject, repo, name, manifestpath)
+	err = PublishManifest(fullproject, repo, name, manifestpath, SkipBootkit)
 	if err != nil {
 		return errors.Wrapf(err, "Failed writing manifest artifacts to local zot")
 	}

--- a/pkg/trust/const.go
+++ b/pkg/trust/const.go
@@ -57,4 +57,5 @@ var SBFPartitionTypeID = [16]byte{
 const MiB, GiB = uint64(1024 * 1024), uint64(1024 * 1024 * 1024)
 
 var Version string
+var RelVersion string
 var BootkitVersion string

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -260,7 +260,7 @@ function good_install {
 	write_install_yaml "$spectype"
 	./mosb manifest publish \
 		--repo ${ZOT_HOST}:${ZOT_PORT} --name puzzleos/install:1.0.0 \
-		--project snakeoil:default $TMPD/manifest.yaml
+		--project snakeoil:default --skip-bootkit $TMPD/manifest.yaml
 	rm $TMPD/manifest.yaml
 	mkdir -p $TMPD/factory/secure
 	cp "$CA_PEM" "$TMPD/factory/secure/manifestCA.pem"

--- a/tests/launch.bats
+++ b/tests/launch.bats
@@ -18,18 +18,12 @@ function teardown() {
 	# Publish a manifest pointing at an rfs on zothub.io
 	# TODO - we do need to include a bootkit layer to set up
 	# an ESP.
+	git describe --abbrev=0
 	cat > "${TMPD}/manifest.yaml" << EOF
 version: 1
 product: default
 update_type: complete
 targets:
-  - service_name: hostfs
-    source: "docker://zothub.io/machine/bootkit/demo-target-rootfs:0.0.4-squashfs"
-    version: 1.0.0
-    service_type: hostfs
-    nsgroup: "none"
-    network:
-      type: none
   - service_name: zot
     source: "docker://zothub.io/machine/bootkit/demo-zot:0.0.4-squashfs"
     version: 1.0.0
@@ -41,15 +35,9 @@ targets:
       ports:
         - host: 80
           container: 5000
-  - service_name: bootkit
-    source: "oci:$HOME/.local/share/machine/trust/keys/snakeoil/bootkit/oci:bootkit-squashfs"
-    version: 1.0.0
-    service_type: fs-only
-    nsgroup: "none"
-    network:
-      type: none
 EOF
 
+	cat "${TMPD}/manifest.yaml"
 	mosb --debug manifest publish \
 	  --project snakeoil:default \
 	  --repo 127.0.0.1:${ZOT_PORT} --name machine/install:1.0.0 \

--- a/tests/mount.bats
+++ b/tests/mount.bats
@@ -31,7 +31,7 @@ EOF
 @test "mount ro livecd filesystem" {
 	write_install_yaml "livecd"
 
-	./mosb manifest publish --product snakeoil:default \
+	./mosb manifest publish --product snakeoil:default --skip-bootkit \
 		--repo ${ZOT_HOST}:${ZOT_PORT} --name machine/livecd:1.0.0 \
 		$TMPD/manifest.yaml
 
@@ -59,7 +59,7 @@ EOF
 @test "mount rw livecd filesystem" {
 	write_install_yaml "livecd"
 
-	./mosb manifest publish --product snakeoil:default \
+	./mosb manifest publish --product snakeoil:default --skip-bootkit \
 		--repo ${ZOT_HOST}:${ZOT_PORT} --name machine/livecd:1.0.0 \
 		$TMPD/manifest.yaml
 


### PR DESCRIPTION
If bootkit layer is not specified, then add the one for the specified trust org.

If hostfs layer is not specified, use the upstream demo one.

This makes less paperwork for the user.